### PR TITLE
Add Git repository to appinfo

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,6 +19,7 @@
     <website>https://www.sendent.nl</website>
 
     <bugs>https://sendent.nl/support</bugs>
+    <repository>https://github.com/Sendent-B-V/Sendent-App-for-Nextcloud.git</repository>
     <screenshot>https://download.sendent.nl/serverapp/1.0.0/sendentbanner.png</screenshot>
     <screenshot>https://download.sendent.nl/serverapp/1.0.0/sharefilesuploading.png</screenshot>
     <screenshot>https://download.sendent.nl/serverapp/1.0.0/sharefilesfiles.png</screenshot>


### PR DESCRIPTION
When trying to find the source repository of Sendent, I only got directed to the right repository after asking @leonvandebroek on [GitHub](https://github.com/aszlig/avonc/commit/28b8a662340683b0c065dd5e5164d69e25890114#commitcomment-50667757).

To make sure others can find the repository, let's add it to the appinfo specification.