### PR TITLE
files_retention app moved its API's routes to the '/ocsapp' prefix in version 1.14 (for NC 25)

### DIFF
--- a/lib/Http/AppVersionHttpClient.php
+++ b/lib/Http/AppVersionHttpClient.php
@@ -3,7 +3,6 @@
 namespace OCA\Sendent\Http;
 
 use Exception;
-use OCA\Sendent\Db\License;
 use Psr\Log\LoggerInterface;
 use OCA\Sendent\Http\Dto\AppVersionResponse;
 
@@ -41,12 +40,11 @@ class AppVersionHttpClient {
 
 				return $appVersionResponse;
 			}
-
 		} catch (Exception $e) {
 			$this->logger->error('AppVersionHttpClient-latest-EXCEPTION: ' . $e->getMessage(), [
 				'exception' => $e,
 			]);
 			return null;
+		}
 	}
-}
 }

--- a/lib/Http/Dto/AppVersionResponse.php
+++ b/lib/Http/Dto/AppVersionResponse.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Sendent\Http\Dto;
 
-use OCA\Sendent\Db\License;
 use JsonSerializable;
 
 class AppVersionResponse implements JsonSerializable {
@@ -17,7 +16,6 @@ class AppVersionResponse implements JsonSerializable {
 
 	public function __construct() {
 		// add types in constructor
-		
 	}
 	public function jsonSerialize() {
 		return [

--- a/lib/Http/LicenseHttpClient.php
+++ b/lib/Http/LicenseHttpClient.php
@@ -21,7 +21,7 @@ class LicenseHttpClient {
 	protected $baseUrl;
 
 	public function __construct(IClientService $clientService, LoggerInterface $logger, string $baseUrl = "https://api.scwcloud.sendent.nl/") {
-	// public function __construct(IClientService $clientService, LoggerInterface $logger, string $baseUrl = "http://localhost:8085/") {
+		// public function __construct(IClientService $clientService, LoggerInterface $logger, string $baseUrl = "http://localhost:8085/") {
 		$this->client = $clientService->newClient();
 		$this->logger = $logger;
 		$this->baseUrl = $baseUrl;

--- a/lib/Service/InitialLoadManager.php
+++ b/lib/Service/InitialLoadManager.php
@@ -100,7 +100,7 @@ class InitialLoadManager {
 			if ($this->SettingKeyMapper->settingKeyCount("202") < 1) {
 				$this->addTalkEnabledUpdate();
 			}
-			if($this->SettingKeyMapper->settingKeyCount("301") < 1) {
+			if ($this->SettingKeyMapper->settingKeyCount("301") < 1) {
 				$this->addGuestAccountSettings();
 			}
 			$this->fixPaths();
@@ -600,7 +600,7 @@ class InitialLoadManager {
 		return $this->getHTMLTemplate('sharefolderhtml');
 	}
 
-	public function getguestaccountshtml(): string{
+	public function getguestaccountshtml(): string {
 		return $this->getHTMLTemplate('guestaccountshtml');
 	}
 

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -21,11 +21,17 @@ export interface WorkflowData {
 }
 
 export interface RetentionData {
-    id: number,
-    tagid: number,
-    timeunit: number,
-    timeamount: number,
-    timeafter: number,
+	ocs: {
+		data: [
+			{
+			    id: number,
+			    tagid: number,
+			    timeunit: number,
+				timeamount: number,
+			    timeafter: number,
+			}
+		]
+	}
 }
 
 export enum RetentionUnit { Days, Weeks, Months, Years }
@@ -70,14 +76,14 @@ class API {
     }
 
     public async getRetentions() {
-        const url = generateUrl('apps/files_retention/api/v1/retentions');
-        const response = await axios.get<RetentionData[]>(url);
+        const url = generateUrl('ocsapp/apps/files_retention/api/v1/retentions');
+        const response = await axios.get<RetentionData>(url);
 
-        return response.data;
+        return response.data.ocs.data;
     }
 
     public async createRetention(tagId: number, timeAmount: number, timeUnit = RetentionUnit.Days, timeAfter = RetentionAfter.Modification) {
-        const url = generateUrl('apps/files_retention/api/v1/retentions');
+        const url = generateUrl('ocsapp/apps/files_retention/api/v1/retentions');
         const response = await axios.post<RetentionData>(url, {
             tagid: tagId,
             timeafter: timeAfter,
@@ -85,7 +91,7 @@ class API {
             timeunit: timeUnit,
         });
 
-        return response.data;
+        return response.data.ocs.data;
     }
 
     public async getTag(tagId: number) {

--- a/src/retentionAssistant.ts
+++ b/src/retentionAssistant.ts
@@ -181,6 +181,7 @@ class RetentionAssistant {
         let hasRemovedTag = false;
         let hasExpiredTag = false;
 
+		console.log(retentions)
         for (const retention of retentions) {
             if (retention.tagid === this.tags[CONFIG_REMOVED_TAG]) {
                 hasRemovedTag = true;


### PR DESCRIPTION
So, this patch fixes the issue on NC25 but would break on NC24 and lower.

Do not apply to the NC24 and lower compatible versions of your app

Signed-off-by: Cyrille Bollu <cyrille@debian-BULLSEYE-live-builder-AMD64>