### PR TITLE
Fix to retention assistant's icons not being displayed in NC25.

### DIFF
--- a/src/retentionAssistant.scss
+++ b/src/retentionAssistant.scss
@@ -27,11 +27,11 @@
 
     &[data-state="fail"]::before {
         content: '';
-        background-image: var(--icon-error-e9322d);
+        background-image: var(--icon-error-color-red);
     }
 
     &[data-state="success"]::before {
         content: '';
-        background-image: var(--icon-checkmark-46ba61);
+        background-image: var(--icon-checkmark-color-green);
     }
 }


### PR DESCRIPTION
This problem is caused by a breaking change: https://help.nextcloud.com/t/scss-support-dropped-with-nextcloud-25/141471

/!\ This change is not backward compatible (ie: this will break icons when running on NC versions lower than 25)